### PR TITLE
Add unit tests and refactor go-octoprint API calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
-name: Build and test Go
+name: Test octoprint-telegraf-plugin
 on: [push, pull_request]
 jobs:
   build:
-    name: Build
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,5 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v1
  
-      - name: Build
-        run: go build .
-
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Build and test Go
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+
+      - name: Check out source code
+        uses: actions/checkout@v1
+ 
+      - name: Build
+        run: go build .
+
+      - name: Test
+        run: go test -v ./...

--- a/plugins/inputs/octoprint/octoapi.go
+++ b/plugins/inputs/octoprint/octoapi.go
@@ -1,0 +1,45 @@
+package octoprint
+
+import (
+	gooctoprint "github.com/mcuadros/go-octoprint"
+)
+
+// OctoAPI an interface for external connections made by go-octoprint
+type OctoAPI interface {
+	StateRequest() (*gooctoprint.FullStateResponse, error)
+	ConnectionRequest() (*gooctoprint.ConnectionResponse, error)
+}
+
+// GoOcto implements the OctoAPI interface to expose API calls for the go-octoprint library
+type GoOcto struct {
+	client *gooctoprint.Client
+}
+
+// NewGoOcto returns a GoOcto instances with a valid go-octoprint client
+func NewGoOcto(URL string, APIKey string) *GoOcto {
+	var goOcto GoOcto
+	goOcto.client = gooctoprint.NewClient(URL, APIKey)
+	return &goOcto
+}
+
+// StateRequest uses the go-octoprint client to query octoprint's API For the current state
+func (o *GoOcto) StateRequest() (*gooctoprint.FullStateResponse, error) {
+	r := gooctoprint.StateRequest{}
+	s, err := r.Do(o.client)
+	if err != nil {
+		return &gooctoprint.FullStateResponse{}, err
+	}
+
+	return s, nil
+}
+
+// ConnectionRequest uses the go-octoprint clien to query octoprint's API for the current connection information
+func (o *GoOcto) ConnectionRequest() (*gooctoprint.ConnectionResponse, error) {
+	r := gooctoprint.ConnectionRequest{}
+	c, err := r.Do(o.client)
+	if err != nil {
+		return &gooctoprint.ConnectionResponse{}, err
+	}
+
+	return c, err
+}

--- a/plugins/inputs/octoprint/octoprint.go
+++ b/plugins/inputs/octoprint/octoprint.go
@@ -3,14 +3,13 @@ package octoprint
 import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	octoapi "github.com/mcuadros/go-octoprint"
 )
 
 // Octoprint - plugins main structure
 type Octoprint struct {
 	URL    string `toml:"url"`
 	APIKey string `toml:"apikey"`
-	client *octoapi.Client
+	API    OctoAPI
 }
 
 // Description returns the plugin description
@@ -32,14 +31,50 @@ func (o *Octoprint) SampleConfig() string {
 
 // Init setup the octoprint client
 func (o *Octoprint) Init() error {
-	o.client = octoapi.NewClient(o.URL, o.APIKey)
+	o.API = NewGoOcto(o.URL, o.APIKey)
 	return nil
+}
+
+// Tool defines a tool on the 3d printer (e.g. hotend)
+type Tool struct {
+	Name       string
+	ActualTemp float64
+	TargetTemp float64
+}
+
+// ToolInfo returns a list of tools on the connected 3d printer
+func (o *Octoprint) ToolInfo() ([]Tool, error) {
+	s, err := o.API.StateRequest()
+	if err != nil {
+		return []Tool{}, err
+	}
+
+	var tools []Tool
+	for toolName, state := range s.Temperature.Current {
+		var t Tool
+		t.Name = toolName
+		t.ActualTemp = state.Actual
+		t.TargetTemp = state.Target
+		tools = append(tools, t)
+	}
+
+	return tools, nil
+}
+
+// State returns the current state of the 3d printer (e.g. printing)
+func (o *Octoprint) State() (string, error) {
+	c, err := o.API.ConnectionRequest()
+	if err != nil {
+		return "", err
+	}
+
+	return string(c.Current.State), nil
 }
 
 // Gather OctoPrint metrics
 func (o *Octoprint) Gather(acc telegraf.Accumulator) error {
 
-	state, _ := o.getState()
+	state, _ := o.State()
 
 	acc.AddFields("state",
 		map[string]interface{}{
@@ -50,57 +85,22 @@ func (o *Octoprint) Gather(acc telegraf.Accumulator) error {
 		},
 	)
 
-	tools, _ := o.getToolInfo()
+	tools, _ := o.ToolInfo()
 
 	for _, t := range tools {
 		acc.AddFields("tool",
 			map[string]interface{}{
-				"name":       t.name,
-				"actualTemp": t.actualTemp,
-				"targetTemp": t.targetTemp,
+				"name":       t.Name,
+				"actualTemp": t.ActualTemp,
+				"targetTemp": t.TargetTemp,
 			},
 			map[string]string{
-				"name": t.name,
+				"name": t.Name,
 			},
 		)
 	}
 
 	return nil
-}
-
-func (o *Octoprint) getState() (string, error) {
-	r := octoapi.ConnectionRequest{}
-	s, err := r.Do(o.client)
-	if err != nil {
-		return "", err
-	}
-
-	return string(s.Current.State), nil
-}
-
-type tool struct {
-	name       string
-	actualTemp float64
-	targetTemp float64
-}
-
-func (o *Octoprint) getToolInfo() ([]tool, error) {
-	r := octoapi.StateRequest{}
-	s, err := r.Do(o.client)
-	if err != nil {
-		return []tool{}, err
-	}
-
-	var tools []tool
-	for toolName, state := range s.Temperature.Current {
-		var t tool
-		t.name = toolName
-		t.actualTemp = state.Actual
-		t.targetTemp = state.Target
-		tools = append(tools, t)
-	}
-
-	return tools, nil
 }
 
 func init() {

--- a/plugins/inputs/octoprint/octoprint_test.go
+++ b/plugins/inputs/octoprint/octoprint_test.go
@@ -1,0 +1,71 @@
+package octoprint
+
+import (
+	"testing"
+
+	gooctoprint "github.com/mcuadros/go-octoprint"
+)
+
+type MockOctoAPI struct{}
+
+func (m *MockOctoAPI) StateRequest() (*gooctoprint.FullStateResponse, error) {
+	var t gooctoprint.TemperatureData
+	t.Actual = 200
+	t.Target = 200
+
+	var r gooctoprint.FullStateResponse
+	r.Temperature.Current = make(map[string]gooctoprint.TemperatureData)
+	r.Temperature.Current["tool0"] = t
+
+	return &r, nil
+}
+
+func (m *MockOctoAPI) ConnectionRequest() (*gooctoprint.ConnectionResponse, error) {
+	var c gooctoprint.ConnectionResponse
+	c.Current.State = "printing"
+	return &c, nil
+}
+
+func TestToolInfo(t *testing.T) {
+	o := Octoprint{}
+	o.API = &MockOctoAPI{}
+	toolInfo, err := o.ToolInfo()
+	if err != nil {
+		t.Errorf("Failed to get tool info, %s", err)
+	}
+
+	if len(toolInfo) == 0 {
+		t.Errorf("No tools returned")
+	}
+
+	var expectedTool Tool
+	expectedTool.ActualTemp = 200
+	expectedTool.TargetTemp = 200
+	expectedToolName := "tool0"
+
+	if toolInfo[0].ActualTemp != expectedTool.ActualTemp {
+		t.Errorf("Wrong actual temp returned, got: %f, want: %f", toolInfo[0].ActualTemp, expectedTool.ActualTemp)
+	}
+	if toolInfo[0].TargetTemp != expectedTool.TargetTemp {
+		t.Errorf("Wrong actual temp returned, got: %f, want: %f", toolInfo[0].TargetTemp, expectedTool.TargetTemp)
+	}
+	if toolInfo[0].Name != expectedToolName {
+		t.Errorf("Wrong actual temp returned, got: %s, want: %s", toolInfo[0].Name, expectedToolName)
+	}
+
+}
+
+func TestState(t *testing.T) {
+	o := Octoprint{}
+	o.API = &MockOctoAPI{}
+	state, err := o.State()
+	if err != nil {
+		t.Errorf("Failed to get state, %s", err.Error())
+	}
+
+	expectedState := "printing"
+
+	if state != expectedState {
+		t.Errorf("Returned invalid state, got: %s, want: %s", state, expectedState)
+	}
+}


### PR DESCRIPTION
Created two units tests for the happy cases for getting tool info and current state of the 3d printer. Refactored the go-octoprint package's functions that perform the API calls behind an interface to mock them out easily when testing.

Added a github-actions file to run the tests.