### PR TITLE
Add support for filament manager plugin with external PSQL database

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ journalctl -l -u telegraf.service -b -n 10
 
 * [External plugin overview](https://github.com/influxdata/telegraf/blob/master/plugins/common/shim/README.md)
 * [Examples of other external plugins](https://github.com/influxdata/telegraf/blob/master/EXTERNAL_PLUGINS.md)
+* [Example setting up external Postgres DB For filament manager on Raspberry PI](https://github.com/malnvenshorn/OctoPrint-FilamentManager/wiki/Setup-PostgreSQL-on-Raspbian-(Stretch))
 
 ## Example Dashboard
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ url="http://xxx.xxx.x.xxx:xxx/"
 apikey=""
 ```
 
+If you have the [Filament Manager Plugin](https://plugins.octoprint.org/plugins/filamentmanager/) then you can configure the plugin to use the external filament manager database,
+[Follow this guide for setup on raspberry pi](https://github.com/malnvenshorn/OctoPrint-FilamentManager/wiki/Setup-PostgreSQL-on-Raspbian-(Stretch)).
+
+Example of an updated plugin.conf to support the postgres database
+
+```toml
+[[inputs.octoprint]]
+url="http://xxx.xxx.x.xxx:xxx/"
+apikey=""
+dbnamepsql="octoprint_filamentmanager"
+userpsql="octoprint"
+passpsql="xxxx"
+ip="xxx.xxx.x.xxx"
+```
+
 To integrate with telegraf, extend the telegraf.conf using the following example
 
 ```toml

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	github.com/influxdata/telegraf v1.15.3
+	github.com/lib/pq v1.3.0
 	github.com/mcuadros/go-octoprint v0.0.0-20190830083709-64ce23ac5e2d
 )


### PR DESCRIPTION
Resolving pull request #2 

The [Filament Manager Plugin](https://plugins.octoprint.org/plugins/filamentmanager/) supports defining an external PSQL database ([Follow this guide for setup on raspberry pi](https://github.com/malnvenshorn/OctoPrint-FilamentManager/wiki/Setup-PostgreSQL-on-Raspbian-(Stretch))). This pull request adds optional settings to define a database name, username/password, and the IP that the database is hosted on, in order to connect to the DB and gather data from the profile table which defines the vendor and material type of a spool.

Here is an example of a dashboard:

![image](https://user-images.githubusercontent.com/3441183/95163937-999e0880-076e-11eb-9e4a-51d615f76e12.png)
